### PR TITLE
Default Bluetooth name for bittle has changed

### DIFF
--- a/pyBittle/bluetoothManager.py
+++ b/pyBittle/bluetoothManager.py
@@ -144,7 +144,7 @@ class BluetoothManager:
             raise TypeError("Value type must be bool.")
 
         search_name = self.name if not get_first_bittle and self.name else \
-            "BittleSPP"
+            "Petoi"
         paired_devices = self.get_paired_devices()
 
         for address, name in list(paired_devices):


### PR DESCRIPTION
The default search for the device name in bluetoothManager.py has changed from BittleSPP-XXXXX to Petoi-XXX, this search name changed is needed on line 147 "Petoi" for the code to work out the box rather than passing search name into the class constructor ( which isn't shown in the examples so hard to work out for new users )